### PR TITLE
Tiny modification for the lock key.

### DIFF
--- a/src/Infrastructure.Persistence.Common/Extensions/EventNotifyingStoreExtensions.cs
+++ b/src/Infrastructure.Persistence.Common/Extensions/EventNotifyingStoreExtensions.cs
@@ -46,7 +46,7 @@ public static class EventNotifyingStoreExtensions
         // definitely not to guard against access to any and all aggregate instances and types across the codebase
         // (since that would definitely slow down writing all aggregates events in this whole executable process,
         // and cause unacceptable performance issues).
-        var lockKey = aggregate.Id.ToString()!;
+        var lockKey = aggregate.Id.Value;
         using (await PublishingPipelineSection.LockAsync(lockKey, cancellationToken))
         {
             var saved = await onSaveEventStreamToStore(aggregate, changedEvents, cancellationToken);


### PR DESCRIPTION
In general, using .ToString() for building the lock key in AsyncKeyedLock is wrong so this piqued my interest. I thought perhaps that Id was of type int, and thus using AsyncKeyedLocker<int> would have made more sense.