### PR TITLE
Fixes #135. isOrganizationSuccess causes state oscillation

### DIFF
--- a/src/Hosts/WebsiteHost/ClientApp/src/framework/providers/CurrentUserContext.tsx
+++ b/src/Hosts/WebsiteHost/ClientApp/src/framework/providers/CurrentUserContext.tsx
@@ -50,7 +50,7 @@ export const CurrentUserProvider = ({ children }: CurrentUserProviderProps) => {
     if (profileHasDefaultOrganization()) {
       getOrganization({ path: { Id: callerProfile!.defaultOrganizationId } } as GetOrganizationData);
     }
-  }, [callerProfile?.defaultOrganizationId, isProfileSuccess, isOrganizationSuccess]);
+  }, [callerProfile?.defaultOrganizationId, isProfileSuccess]);
 
   // If we have an error fetching the current user profile,
   // and we're not already logging out, then log out now to remove any authenticated state (i.e. cookies).


### PR DESCRIPTION
isOrganizationSuccess is derived from ActionQuery's isCompleted. When a user's default organization isn't accessible anymore, it causes a 403 error.

Each failed fetch causes this state oscillation:

1. Before fetch: isFetching = false, isError = true -> isCompleted = false
2. Fetch starts: setIsFetching(true) -> isCompleted = undefined
3. 403 returnsL setIsFetching(false) -> setIsError(true) -> isCompleted = false
4. Go back to Step 1 - isOrganizationSuccess changed from undefined to false, useEffect fires again.

Each transition triggers the useEffect, creating an infinite loop of network requests.

Removing isOrganizationSuccess from the dependency array of this useEffect should fix this. defaultOrganizationId and isProfileSuccess would re-fetch appropriately (fetch Organization when profile loads successfully / if default organization changes)